### PR TITLE
Fix homepage random search always re-fetching client-side

### DIFF
--- a/sql/migrations/fix-episode-transcript-versions-rls.sql
+++ b/sql/migrations/fix-episode-transcript-versions-rls.sql
@@ -1,0 +1,27 @@
+-- Migration: Allow public read access to episode_transcript_versions and
+-- transcript_lines_archive.
+--
+-- These tables were created by add-episode-version-history.sql with RLS
+-- enabled by default and no SELECT policy ever added, unlike episodes /
+-- transcript_lines / users in supabase-schema.sql. With RLS on and zero
+-- policies, Postgres default-denies every role except postgres/service_role
+-- - so anon (and authenticated) reads silently return zero rows, no error.
+--
+-- Effect: the "X edits" history badge and history panel on /ep/[id] have
+-- never been visible to unauthenticated visitors, since HistoryService
+-- queries these tables with the public anon key. This makes them public
+-- read-only, same trust level as the already-public episodes/transcript_lines.
+--
+-- Neither table exposes anything sensitive once readable: episode_transcript_versions
+-- includes a created_by UUID, but the users table stays locked to
+-- "auth.uid() = id" (see supabase-schema.sql), so the users!created_by
+-- embedded join used for display names keeps resolving to null/"Unknown"
+-- for anonymous visitors - no email or username leaks through this change.
+
+CREATE POLICY "Anyone can read episode transcript versions"
+ON episode_transcript_versions FOR SELECT
+USING (true);
+
+CREATE POLICY "Anyone can read transcript lines archive"
+ON transcript_lines_archive FOR SELECT
+USING (true);

--- a/src/lib/components/search/SearchContainer.svelte
+++ b/src/lib/components/search/SearchContainer.svelte
@@ -42,7 +42,14 @@
 	// svelte-ignore state_referenced_locally
 	filtersState.editedOnly = initialEditedOnly;
 	let inputValue = $state(searchState.query);
-	let hasInitialized = false;
+	// Each effect below needs its own flag - they both guard against
+	// re-searching when SSR already provided initialHits, but a shared flag
+	// let the first effect's mount run flip it before the second effect's
+	// mount run ever read it, silently defeating that guard and causing a
+	// redundant client-side re-search (bypassing the /api/search CDN cache)
+	// on every single page load.
+	let hasInitializedSearchEffect = false;
+	let hasInitializedFiltersEffect = false;
 
 	async function handleSearch(query?: string) {
 		if (query !== undefined) {
@@ -114,8 +121,8 @@
 	$effect(() => {
 		void inputValue;
 
-		if (!hasInitialized) {
-			hasInitialized = true;
+		if (!hasInitializedSearchEffect) {
+			hasInitializedSearchEffect = true;
 			// If we have initial hits, don't search automatically
 			if (initialHits.length > 0) {
 				return;
@@ -131,8 +138,11 @@
 		void filtersState.editedOnly;
 
 		// Don't search automatically if we haven't initialized yet and have initial hits
-		if (!hasInitialized && initialHits.length > 0) {
-			return;
+		if (!hasInitializedFiltersEffect) {
+			hasInitializedFiltersEffect = true;
+			if (initialHits.length > 0) {
+				return;
+			}
 		}
 
 		clearTimeout(searchTimeoutId);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -10,7 +10,16 @@ export async function load({ url, fetch }) {
 	const searchQuery = query || newRandom();
 	if (searchQuery) {
 		try {
-			const searchParams = createSearchParams({ query: searchQuery, filter, editedOnly });
+			// createSearchParams defaults offset to 20 (meant for the "load more"
+			// caller, which always passes its own explicit offset) - the initial
+			// page-load search needs page one, or it silently skips the first 20
+			// matches and often comes back empty for the shorter curated terms.
+			const searchParams = createSearchParams({
+				query: searchQuery,
+				offset: 0,
+				filter,
+				editedOnly
+			});
 			const response = await fetch(`/api/search?${searchParams}`);
 			if (response.ok) {
 				const data = await response.json();


### PR DESCRIPTION
## Summary
- Fix the homepage's default random-query search silently requesting `offset: 20` instead of `0`, which caused the SSR search to skip the first 20 matches and almost always come back empty for the shorter curated terms in `randomQuery`.
- Fix `SearchContainer.svelte`'s two mount `$effect`s sharing a single `hasInitialized` flag, which silently defeated the "skip auto-search when SSR already has results" guard in the second effect - causing every homepage load to redo the search client-side against Supabase directly, bypassing the existing 3-day CDN cache on `/api/search`.
- Commit the `episode_transcript_versions`/`transcript_lines_archive` RLS migration file (already applied to production earlier) that was never committed to git - it makes the "X edits" history badge/panel on `/ep/[id]` visible to anonymous visitors.

## Why
Investigating homepage performance (cold FCP was ~2.5s in production) traced back to these two compounding bugs: the SSR search was effectively wasted work (wrong page, usually 0 hits), so the client always had to redo the full search after hydration before real content could render - and that redo bypassed caching entirely. Fixing the offset means SSR now returns real results; fixing the effect flags means the client stops throwing that work away.

## Test plan
- [x] Reproduced the double-fetch/zero-hits bug locally (server logs showed `offset:20`/`hits:0` on every homepage load; browser network showed 2 redundant Supabase RPC calls on mount)
- [x] Verified fix: homepage load now does one server-side search with real hits (e.g. `hits:18`), zero redundant client-side Supabase calls on mount
- [x] Verified typing a new query still fires exactly one client-side search (no regression to interactive search)
- [x] `bun run lint` and `bun run check` pass cleanly